### PR TITLE
Activate plugins for improved privacy and adding cards when linking the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ In a nutshell, each wiki page is a markdown document with some additional functi
 
 All python dependencies can be found in `requirements.txt`.
 You can install them easily with `pip3 install -r requirements.txt`, and then run a preview server for the wiki with the command `mkdocs serve`.
+
+Additionally you will need to install Cairos Graphics, see instructions [here](https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/).
+Alternatively you can (temporarily) disable the `social` plugin in `mkdocs.yml` while working locally, just remember to re-enable it afterwards.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,8 +28,11 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
 plugins:
-  - search:
-      enabled: true
+  - search
+  - privacy
+  - social:
+      cards_layout_options:
+        color: "#295c88"
 extra:
   social:
     - icon: fontawesome/brands/github

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,14 @@
 babel==2.17.0
 backrefs==5.8
+cairocffi==1.7.1
+CairoSVG==2.7.1
 certifi==2025.1.31
+cffi==1.17.1
 charset-normalizer==3.4.1
 click==8.1.8
 colorama==0.4.6
+cssselect2==0.8.0
+defusedxml==0.7.1
 ghp-import==2.1.0
 idna==3.10
 Jinja2==3.1.5
@@ -17,7 +22,9 @@ mkdocs-material-extensions==1.3.1
 packaging==24.2
 paginate==0.5.7
 pathspec==0.12.1
+pillow==10.4.0
 platformdirs==4.3.6
+pycparser==2.22
 Pygments==2.19.1
 pymdown-extensions==10.14.3
 python-dateutil==2.9.0.post0
@@ -25,5 +32,7 @@ PyYAML==6.0.2
 pyyaml_env_tag==0.1
 requests==2.32.3
 six==1.17.0
+tinycss2==1.4.0
 urllib3==2.3.0
 watchdog==6.0.0
+webencodings==0.5.1


### PR DESCRIPTION
Updated the plugins:

* Removed redundant `enable:true` for `search`
* Enabled `privacy` plugin, which will cache external media (fonts, etc) to improve GDPR compliance
* Enabled `social` plugin, which will create cards when linking the wiki in social media